### PR TITLE
Add simple role/language toggle page

### DIFF
--- a/index.html
+++ b/index.html
@@ -405,6 +405,7 @@
             <a href="#" class="lang-btn active" data-lang="en">🇬🇧 English</a>
             <a href="#" class="lang-btn" data-lang="zh">🇨🇳 中文</a>
             <a href="#" class="lang-btn" data-lang="yue">🇭🇰 粵語</a>
+            <a href="toggle.html" class="lang-btn">Demo</a>
         </div>
     </div>
 

--- a/toggle.html
+++ b/toggle.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Role and Language Toggle</title>
+<style>
+body {
+    font-family: Arial, sans-serif;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 40px;
+}
+.section {
+    margin-bottom: 20px;
+}
+label {
+    margin-right: 10px;
+}
+.result {
+    margin-top: 30px;
+    font-size: 1.2em;
+    font-weight: bold;
+}
+</style>
+</head>
+<body>
+<h1>Select Your Role and Language</h1>
+<div class="section" id="role-toggle">
+    <label><input type="radio" name="role" value="Student" checked> Student</label>
+    <label><input type="radio" name="role" value="Tutor"> Tutor</label>
+</div>
+<div class="section" id="lang-toggle">
+    <label><input type="radio" name="language" value="English" checked> English</label>
+    <label><input type="radio" name="language" value="Mandarin"> Mandarin</label>
+</div>
+<div class="result" id="result">You selected: Student - English</div>
+<script>
+function updateResult() {
+    const role = document.querySelector('input[name="role"]:checked').value;
+    const lang = document.querySelector('input[name="language"]:checked').value;
+    document.getElementById('result').textContent = `You selected: ${role} - ${lang}`;
+}
+
+document.getElementById('role-toggle').addEventListener('change', updateResult);
+document.getElementById('lang-toggle').addEventListener('change', updateResult);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a minimal page `toggle.html` with radio buttons to toggle between Student/Tutor and English/Mandarin

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b2b6e2884832887ed1c6bf8fb2fb0